### PR TITLE
MET-457 Add call to get the workflow execution by execution id instea…

### DIFF
--- a/metis-common/src/main/java/eu/europeana/metis/RestEndpoints.java
+++ b/metis-common/src/main/java/eu/europeana/metis/RestEndpoints.java
@@ -37,7 +37,7 @@ public final class RestEndpoints {
   public static final String ORCHESTRATOR_WORKFLOWS_DATASETID_EXECUTE_DIRECT = "/orchestrator/workflows/{datasetId}/execute/direct";
   public static final String ORCHESTRATOR_WORKFLOWS_SCHEDULE = "/orchestrator/workflows/schedule";
   public static final String ORCHESTRATOR_WORKFLOWS_SCHEDULE_DATASETID = "/orchestrator/workflows/schedule/{datasetId}";
-  public static final String ORCHESTRATOR_WORKFLOWS_EXECUTION_DATASETID = "/orchestrator/workflows/execution/{datasetId}";
+  public static final String ORCHESTRATOR_WORKFLOWS_EXECUTION_EXECUTIONID = "/orchestrator/workflows/execution/{executionId}";
   public static final String ORCHESTRATOR_WORKFLOWS_EXECUTIONS_DATASETID = "/orchestrator/workflows/executions/{datasetId}";
   public static final String ORCHESTRATOR_WORKFLOWS_EXECUTIONS = "/orchestrator/workflows/executions";
   public static final String ORCHESTRATOR_PROXIES_TOPOLOGY_TASK_LOGS = "/orchestrator/proxies/{topologyName}/task/{externalTaskId}/logs";

--- a/metis-core/metis-core-common/src/main/java/eu/europeana/metis/core/test/utils/TestObjectFactory.java
+++ b/metis-core/metis-core-common/src/main/java/eu/europeana/metis/core/test/utils/TestObjectFactory.java
@@ -31,6 +31,7 @@ import org.bson.types.ObjectId;
 public class TestObjectFactory {
 
   public static final int DATASETID = 100;
+  public static final String EXECUTIONID = "5a5dc67ba458bb00083d49e3";
   public static final String DATASETNAME = "datasetName";
   public static final String WORKFLOWOWNER = "workflowOwner";
   public static final String WORKFLOWNAME = "workflowName";

--- a/metis-core/metis-core-common/src/main/java/eu/europeana/metis/core/workflow/WorkflowExecution.java
+++ b/metis-core/metis-core-common/src/main/java/eu/europeana/metis/core/workflow/WorkflowExecution.java
@@ -65,8 +65,8 @@ public class WorkflowExecution implements HasMongoObjectId {
 
   private List<AbstractMetisPlugin> metisPlugins = new ArrayList<>();
 
-  //Keep this constructor
   public WorkflowExecution() {
+    //Required for json serialization
   }
 
   public WorkflowExecution(Dataset dataset, Workflow workflow, int workflowPriority) {
@@ -90,18 +90,14 @@ public class WorkflowExecution implements HasMongoObjectId {
         case HTTP_HARVEST:
           HTTPHarvestPlugin httpHarvestPlugin = new HTTPHarvestPlugin(harvestingMetadata);
           httpHarvestPlugin
-              .setId(
-                  new ObjectId().toString() + "-" + httpHarvestPlugin.getPluginType().name());
+              .setId(new ObjectId().toString() + "-" + httpHarvestPlugin.getPluginType().name());
           metisPlugins.add(httpHarvestPlugin);
           break;
         case OAIPMH_HARVEST:
           OaipmhHarvestPlugin oaipmhHarvestPlugin = new OaipmhHarvestPlugin(harvestingMetadata);
           oaipmhHarvestPlugin
-              .setId(
-                  new ObjectId().toString() + "-" + oaipmhHarvestPlugin.getPluginType().name());
+              .setId(new ObjectId().toString() + "-" + oaipmhHarvestPlugin.getPluginType().name());
           metisPlugins.add(oaipmhHarvestPlugin);
-          break;
-        case NULL:
           break;
         default:
           break;
@@ -128,8 +124,7 @@ public class WorkflowExecution implements HasMongoObjectId {
     }
   }
 
-  public void setAllRunningAndInqueuePluginsToCancelled()
-  {
+  public void setAllRunningAndInqueuePluginsToCancelled() {
     this.setWorkflowStatus(WorkflowStatus.CANCELLED);
     for (AbstractMetisPlugin metisPlugin :
         this.getMetisPlugins()) {
@@ -183,7 +178,7 @@ public class WorkflowExecution implements HasMongoObjectId {
     this.workflowStatus = workflowStatus;
   }
 
-  public long getDatasetId() {
+  public int getDatasetId() {
     return datasetId;
   }
 

--- a/metis-core/metis-core-rest/src/main/java/eu/europeana/metis/core/rest/OrchestratorController.java
+++ b/metis-core/metis-core-rest/src/main/java/eu/europeana/metis/core/rest/OrchestratorController.java
@@ -113,57 +113,59 @@ public class OrchestratorController {
       MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
-  public void addWorkflowInQueueOfWorkflowExecutions(
+  public WorkflowExecution addWorkflowInQueueOfWorkflowExecutions(
       @PathVariable("datasetId") int datasetId,
       @RequestParam("workflowOwner") String workflowOwner,
       @RequestParam("workflowName") String workflowName,
       @RequestParam(value = "priority", defaultValue = "0") int priority)
       throws WorkflowExecutionAlreadyExistsException, NoDatasetFoundException, NoWorkflowFoundException {
-    orchestratorService
+    WorkflowExecution workflowExecution = orchestratorService
         .addWorkflowInQueueOfWorkflowExecutions(datasetId, workflowOwner,
             workflowName, priority);
     LOGGER.info(
         "WorkflowExecution for datasetId '{}' with workflowOwner '{}' and workflowName '{}' added to queue",
         datasetId, workflowOwner, workflowName);
+    return workflowExecution;
   }
 
   @RequestMapping(value = RestEndpoints.ORCHESTRATOR_WORKFLOWS_DATASETID_EXECUTE_DIRECT, method = RequestMethod.POST, produces = {
       MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   @ResponseStatus(HttpStatus.CREATED)
   @ResponseBody
-  public void addWorkflowInQueueOfWorkflowExecutions(
+  public WorkflowExecution addWorkflowInQueueOfWorkflowExecutions(
       @PathVariable("datasetId") int datasetId, @RequestBody Workflow workflow,
       @RequestParam(value = "priority", defaultValue = "0") int priority)
       throws WorkflowExecutionAlreadyExistsException, NoDatasetFoundException, WorkflowAlreadyExistsException {
-    orchestratorService
+    WorkflowExecution workflowExecution = orchestratorService
         .addWorkflowInQueueOfWorkflowExecutions(datasetId, workflow, priority);
     LOGGER.info(
         "WorkflowExecution for datasetId '{}' with workflowOwner '{}' started", datasetId,
         workflow.getWorkflowOwner());
+    return workflowExecution;
   }
 
-  @RequestMapping(value = RestEndpoints.ORCHESTRATOR_WORKFLOWS_EXECUTION_DATASETID, method = RequestMethod.DELETE, produces = {
+  @RequestMapping(value = RestEndpoints.ORCHESTRATOR_WORKFLOWS_EXECUTION_EXECUTIONID, method = RequestMethod.DELETE, produces = {
       MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ResponseBody
   public void cancelWorkflowExecution(
-      @PathVariable("datasetId") int datasetId)
+      @PathVariable("executionId") String executionId)
       throws NoWorkflowExecutionFoundException {
-    orchestratorService.cancelWorkflowExecution(datasetId);
+    orchestratorService.cancelWorkflowExecution(executionId);
     LOGGER.info(
-        "WorkflowExecution for datasetId '{}' is cancelling",
-        datasetId);
+        "WorkflowExecution for executionId '{}' is cancelling",
+        executionId);
   }
 
-  @RequestMapping(value = RestEndpoints.ORCHESTRATOR_WORKFLOWS_EXECUTION_DATASETID, method = RequestMethod.GET, produces = {
+  @RequestMapping(value = RestEndpoints.ORCHESTRATOR_WORKFLOWS_EXECUTION_EXECUTIONID, method = RequestMethod.GET, produces = {
       MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
   @ResponseStatus(HttpStatus.OK)
   @ResponseBody
-  public WorkflowExecution getRunningWorkflowExecution(
-      @PathVariable("datasetId") int datasetId) {
+  public WorkflowExecution getWorkflowExecutionByExecutionId(
+      @PathVariable("executionId") String executionId) {
     WorkflowExecution workflowExecution = orchestratorService
-        .getRunningWorkflowExecution(datasetId);
-    LOGGER.info("WorkflowExecution with datasetId '{}' found", datasetId);
+        .getWorkflowExecutionByExecutionId(executionId);
+    LOGGER.info("WorkflowExecution with executionId '{}' found", executionId);
     return workflowExecution;
   }
 

--- a/metis-core/metis-core-service/src/main/java/eu/europeana/metis/core/dao/WorkflowExecutionDao.java
+++ b/metis-core/metis-core-service/src/main/java/eu/europeana/metis/core/dao/WorkflowExecutionDao.java
@@ -42,7 +42,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     Key<WorkflowExecution> workflowExecutionKey = morphiaDatastoreProvider.getDatastore().save(
         workflowExecution);
     LOGGER.debug(
-        "WorkflowExecution for datasetName '{}' with workflowOwner '{}' and workflowName '{}' created in Mongo",
+        "WorkflowExecution for datasetId '{}' with workflowOwner '{}' and workflowName '{}' created in Mongo",
         workflowExecution.getDatasetId(), workflowExecution.getWorkflowOwner(),
         workflowExecution.getWorkflowName());
     return workflowExecutionKey.getId().toString();
@@ -53,7 +53,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     Key<WorkflowExecution> workflowExecutionKey = morphiaDatastoreProvider.getDatastore().save(
         workflowExecution);
     LOGGER.debug(
-        "WorkflowExecution for datasetName '{}' with workflowOwner '{}' and workflowName '{}' updated in Mongo",
+        "WorkflowExecution for datasetId '{}' with workflowOwner '{}' and workflowName '{}' updated in Mongo",
         workflowExecution.getDatasetId(), workflowExecution.getWorkflowOwner(),
         workflowExecution.getWorkflowName());
     return workflowExecutionKey.getId().toString();
@@ -71,7 +71,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     UpdateResults updateResults = morphiaDatastoreProvider.getDatastore()
         .update(query, workflowExecutionUpdateOperations);
     LOGGER.debug(
-        "WorkflowExecution metisPlugins for datasetName '{}' with workflowOwner '{}' and workflowName '{}' updated in Mongo. (UpdateResults: {})",
+        "WorkflowExecution metisPlugins for datasetId '{}' with workflowOwner '{}' and workflowName '{}' updated in Mongo. (UpdateResults: {})",
         workflowExecution.getDatasetId(), workflowExecution.getWorkflowOwner(),
         workflowExecution.getWorkflowName(), updateResults.getUpdatedCount());
   }
@@ -98,7 +98,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     UpdateResults updateResults = morphiaDatastoreProvider.getDatastore()
         .update(query, workflowExecutionUpdateOperations);
     LOGGER.debug(
-        "WorkflowExecution monitor information for datasetName '{}' with workflowOwner '{}' and workflowName '{}' updated in Mongo. (UpdateResults: {})",
+        "WorkflowExecution monitor information for datasetId '{}' with workflowOwner '{}' and workflowName '{}' updated in Mongo. (UpdateResults: {})",
         workflowExecution.getDatasetId(), workflowExecution.getWorkflowOwner(),
         workflowExecution.getWorkflowName(), updateResults.getUpdatedCount());
   }
@@ -114,7 +114,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     UpdateResults updateResults = morphiaDatastoreProvider.getDatastore()
         .update(query, workflowExecutionUpdateOperations);
     LOGGER.debug(
-        "WorkflowExecution cancelling for datasetName '{}' with workflowOwner '{}' and workflowName '{}' set to true in Mongo. (UpdateResults: {})",
+        "WorkflowExecution cancelling for datasetId '{}' with workflowOwner '{}' and workflowName '{}' set to true in Mongo. (UpdateResults: {})",
         workflowExecution.getDatasetId(), workflowExecution.getWorkflowOwner(),
         workflowExecution.getWorkflowName(), updateResults.getUpdatedCount());
   }
@@ -132,7 +132,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     return false;
   }
 
-  public WorkflowExecution getRunningOrInQueueExecution(long datasetId) {
+  public WorkflowExecution getRunningOrInQueueExecution(int datasetId) {
     Query<WorkflowExecution> query = morphiaDatastoreProvider.getDatastore()
         .find(WorkflowExecution.class)
         .field(DATASET_ID).equal(
@@ -151,7 +151,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
         .project("_id", true).get() != null;
   }
 
-  public String existsAndNotCompleted(long datasetId) {
+  public String existsAndNotCompleted(int datasetId) {
     Query<WorkflowExecution> query = morphiaDatastoreProvider.getDatastore()
         .find(WorkflowExecution.class).field(DATASET_ID).equal(datasetId);
     query.or(query.criteria(WORKFLOW_STATUS).equal(WorkflowStatus.INQUEUE),
@@ -166,16 +166,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     return null;
   }
 
-  public WorkflowExecution getRunningWorkflowExecution(long datasetId) {
-    Query<WorkflowExecution> query = morphiaDatastoreProvider.getDatastore()
-        .createQuery(WorkflowExecution.class);
-    query.field(DATASET_ID).equal(
-        datasetId)
-        .field(WORKFLOW_STATUS).equal(WorkflowStatus.RUNNING);
-    return query.get();
-  }
-
-  public List<WorkflowExecution> getAllWorkflowExecutions(long datasetId,
+  public List<WorkflowExecution> getAllWorkflowExecutions(int datasetId,
       String workflowOwner,
       String workflowName,
       WorkflowStatus workflowStatus, String nextPage) {
@@ -271,7 +262,7 @@ public class WorkflowExecutionDao implements MetisDao<WorkflowExecution, String>
     }
   }
 
-  public boolean deleteAllByDatasetId(long datasetId) {
+  public boolean deleteAllByDatasetId(int datasetId) {
     Query<WorkflowExecution> query = morphiaDatastoreProvider.getDatastore()
         .createQuery(WorkflowExecution.class);
     query.field(DATASET_ID).equal(datasetId);

--- a/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/dao/TestWorkflowExecutionDao.java
+++ b/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/dao/TestWorkflowExecutionDao.java
@@ -202,13 +202,13 @@ public class TestWorkflowExecutionDao {
   }
 
   @Test
-  public void getRunningUserWorkflowExecution() {
+  public void getWorkflowExecutionByExecutionId() {
     WorkflowExecution workflowExecution = TestObjectFactory
         .createUserWorkflowExecutionObject();
     workflowExecution.setWorkflowStatus(WorkflowStatus.RUNNING);
     String objectId = workflowExecutionDao.create(workflowExecution);
     WorkflowExecution runningWorkflowExecution = workflowExecutionDao
-        .getRunningWorkflowExecution(workflowExecution.getDatasetId());
+        .getById(workflowExecution.getId().toString());
     Assert.assertEquals(objectId, runningWorkflowExecution.getId().toString());
   }
 

--- a/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/execution/TestSchedulerExecutor.java
+++ b/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/execution/TestSchedulerExecutor.java
@@ -89,9 +89,8 @@ public class TestSchedulerExecutor {
         .thenReturn(listOfScheduledWorkflowsWithDateDAILY).thenReturn(
         listOfScheduledWorkflowsWithDateWEEKLY).thenReturn(
         listOfScheduledWorkflowsWithDateMONTHLY);
-    doThrow(new NoDatasetFoundException("Some Error")).doNothing().when(orchestratorService)
-        .addWorkflowInQueueOfWorkflowExecutions(anyInt(), anyString(), anyString(),
-            anyInt()); //Throw an exception as well, should continue execution after that
+    when(orchestratorService.addWorkflowInQueueOfWorkflowExecutions(anyInt(), anyString(), anyString(),
+            anyInt())).thenThrow(new NoDatasetFoundException("Some Error")).thenReturn(null); //Throw an exception as well, should continue execution after that
     doNothing().when(rlock).unlock();
 
     schedulerExecutor.run();
@@ -135,9 +134,8 @@ public class TestSchedulerExecutor {
         .thenReturn(listOfScheduledWorkflowsWithDateDAILY).thenReturn(
         listOfScheduledWorkflowsWithDateWEEKLY).thenReturn(
         listOfScheduledWorkflowsWithDateMONTHLY);
-    doThrow(new NoDatasetFoundException("Some Error")).doNothing().when(orchestratorService)
-        .addWorkflowInQueueOfWorkflowExecutions(anyInt(), anyString(), anyString(),
-            anyInt()); //Throw an exception as well, should continue execution after that
+    when(orchestratorService
+        .addWorkflowInQueueOfWorkflowExecutions(anyInt(), anyString(), anyString(), anyInt())).thenThrow(new NoDatasetFoundException("Some Error")).thenReturn(null); //Throw an exception as well, should continue execution after that
     doNothing().when(rlock).unlock();
 
     schedulerExecutor.run();

--- a/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/service/TestOrchestratorService.java
+++ b/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/service/TestOrchestratorService.java
@@ -3,7 +3,6 @@ package eu.europeana.metis.core.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
@@ -170,11 +169,11 @@ public class TestOrchestratorService {
   }
 
   @Test
-  public void getRunningUserWorkflowExecution() {
-    orchestratorService.getRunningWorkflowExecution(anyInt());
+  public void getWorkflowExecutionByExecutionId() {
+    orchestratorService.getWorkflowExecutionByExecutionId(anyString());
     InOrder inOrder = Mockito.inOrder(workflowExecutionDao);
     inOrder.verify(workflowExecutionDao, times(1))
-        .getRunningWorkflowExecution(anyLong());
+        .getById(anyString());
     inOrder.verifyNoMoreInteractions();
   }
 
@@ -346,19 +345,19 @@ public class TestOrchestratorService {
   public void cancelUserWorkflowExecution() throws Exception {
     WorkflowExecution workflowExecution = TestObjectFactory
         .createUserWorkflowExecutionObject();
-    when(workflowExecutionDao.getRunningOrInQueueExecution(TestObjectFactory.DATASETID))
+    when(workflowExecutionDao.getById(TestObjectFactory.EXECUTIONID))
         .thenReturn(workflowExecution);
     doNothing().when(workflowExecutorManager)
         .cancelWorkflowExecution(workflowExecution);
-    orchestratorService.cancelWorkflowExecution(TestObjectFactory.DATASETID);
+    orchestratorService.cancelWorkflowExecution(TestObjectFactory.EXECUTIONID);
   }
 
   @Test(expected = NoWorkflowExecutionFoundException.class)
   public void cancelUserWorkflowExecution_NoUserWorkflowExecutionFoundException()
       throws Exception {
-    when(workflowExecutionDao.getRunningOrInQueueExecution(TestObjectFactory.DATASETID))
+    when(workflowExecutionDao.getById(TestObjectFactory.EXECUTIONID))
         .thenReturn(null);
-    orchestratorService.cancelWorkflowExecution(TestObjectFactory.DATASETID);
+    orchestratorService.cancelWorkflowExecution(TestObjectFactory.EXECUTIONID);
     verifyNoMoreInteractions(workflowExecutorManager);
   }
 
@@ -404,7 +403,7 @@ public class TestOrchestratorService {
         TestObjectFactory.WORKFLOWOWNER, TestObjectFactory.WORKFLOWOWNER, WorkflowStatus.RUNNING,
         objectId);
     verify(workflowExecutionDao, times(1))
-        .getAllWorkflowExecutions(anyLong(), anyString(), anyString(), any(
+        .getAllWorkflowExecutions(anyInt(), anyString(), anyString(), any(
             WorkflowStatus.class), anyString());
     verifyNoMoreInteractions(workflowExecutionDao);
   }


### PR DESCRIPTION
…d of datasetId.

This solves the problem of knowing which workflowExecution to monitor after starting one execution for a datasetId.