### PR TITLE
MET-1073 Add support to indicate solr is ready and searchable from la…

### DIFF
--- a/metis-common/src/main/java/eu/europeana/metis/utils/DateUtils.java
+++ b/metis-common/src/main/java/eu/europeana/metis/utils/DateUtils.java
@@ -28,27 +28,16 @@ public final class DateUtils {
   }
 
   /**
-   * Adds minutes to a provided date.
+   * Modifies a {@link Date} by a {@link TimeUnit} {@code amount}.
+   * <p>This means that the {@code timeUnit} defines the type of the {@code amount} to be added or
+   * subtracted from the {@code date}</p>
    *
-   * @param minutes the minutes to be added
-   * @param date the date used to add minutes to
-   * @return the new date with the added minutes
+   * @param amount the amount of units to be added or subtracted, so it can be a negative value
+   * @param date the date used that will be modified
+   * @return the new converted date
    */
-  public static Date addMinutesToDate(long minutes, Date date) {
+  public static Date modifyDateByTimeUnitAmount(Date date, long amount, TimeUnit timeUnit) {
     long dateInMillis = date.getTime();
-    return new Date(dateInMillis + TimeUnit.MINUTES.toMillis(minutes));
+    return new Date(dateInMillis + TimeUnit.MILLISECONDS.convert(amount, timeUnit));
   }
-
-  /**
-   * Adds minutes to a provided date.
-   *
-   * @param minutes the minutes to be added
-   * @param date the date used to add minutes to
-   * @return the new date with the added minutes
-   */
-  public static Date subtractMinutesToDate(long minutes, Date date) {
-    long dateInMillis = date.getTime();
-    return new Date(dateInMillis - TimeUnit.MINUTES.toMillis(minutes));
-  }
-
 }

--- a/metis-common/src/main/java/eu/europeana/metis/utils/DateUtils.java
+++ b/metis-common/src/main/java/eu/europeana/metis/utils/DateUtils.java
@@ -1,0 +1,54 @@
+package eu.europeana.metis.utils;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * General {@link Date} utilities methods
+ *
+ * @author Simon Tzanakis (Simon.Tzanakis@europeana.eu)
+ * @since 2018-05-31
+ */
+public final class DateUtils {
+
+  private DateUtils() {
+  }
+
+  /**
+   * Calculates the difference in time, of two {@link Date}s, based on a {@link TimeUnit}
+   *
+   * @param pastDate the older date
+   * @param futureDate the newer date
+   * @param timeUnit the time unit used to calculate the difference
+   * @return the amount of {@link TimeUnit}s of the difference
+   */
+  public static long calculateDateDifference(Date pastDate, Date futureDate, TimeUnit timeUnit) {
+    long diffInMillies = futureDate.getTime() - pastDate.getTime();
+    return timeUnit.convert(diffInMillies, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Adds minutes to a provided date.
+   *
+   * @param minutes the minutes to be added
+   * @param date the date used to add minutes to
+   * @return the new date with the added minutes
+   */
+  public static Date addMinutesToDate(long minutes, Date date) {
+    long dateInMillis = date.getTime();
+    return new Date(dateInMillis + TimeUnit.MINUTES.toMillis(minutes));
+  }
+
+  /**
+   * Adds minutes to a provided date.
+   *
+   * @param minutes the minutes to be added
+   * @param date the date used to add minutes to
+   * @return the new date with the added minutes
+   */
+  public static Date subtractMinutesToDate(long minutes, Date date) {
+    long dateInMillis = date.getTime();
+    return new Date(dateInMillis - TimeUnit.MINUTES.toMillis(minutes));
+  }
+
+}

--- a/metis-common/src/main/java/eu/europeana/metis/utils/DateUtils.java
+++ b/metis-common/src/main/java/eu/europeana/metis/utils/DateUtils.java
@@ -29,11 +29,12 @@ public final class DateUtils {
 
   /**
    * Modifies a {@link Date} by a {@link TimeUnit} {@code amount}.
-   * <p>This means that the {@code timeUnit} defines the type of the {@code amount} to be added or
+   * <p>This means that the {@code timeUnit} defines the type of the {@code amount} to be added to or
    * subtracted from the {@code date}</p>
    *
-   * @param amount the amount of units to be added or subtracted, so it can be a negative value
    * @param date the date used that will be modified
+   * @param amount the amount of units to be added or subtracted, so it can be a negative value
+   * @param timeUnit the time unit used define the type of the {@code amount} parameter
    * @return the new converted date
    */
   public static Date modifyDateByTimeUnitAmount(Date date, long amount, TimeUnit timeUnit) {

--- a/metis-core/metis-core-common/src/main/java/eu/europeana/metis/core/dataset/DatasetExecutionInformation.java
+++ b/metis-core/metis-core-common/src/main/java/eu/europeana/metis/core/dataset/DatasetExecutionInformation.java
@@ -8,11 +8,17 @@ import java.util.Date;
  * @since 2018-04-03
  */
 public class DatasetExecutionInformation {
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+  private Date lastPreviewDate;
+  private int lastPreviewRecords;
+  private boolean lastPreviewRecordsReadyForViewing;
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
   private Date firstPublishedDate;
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
   private Date lastPublishedDate;
   private int lastPublishedRecords;
+  private boolean lastPublishedRecordsReadyForViewing;
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
   private Date lastHarvestedDate;
   private int lastHarvestedRecords;
@@ -21,20 +27,46 @@ public class DatasetExecutionInformation {
     //Required for json serialization
   }
 
+  public Date getLastPreviewDate() {
+    return lastPreviewDate == null ? null : new Date(lastPreviewDate.getTime());
+  }
+
+  public void setLastPreviewDate(Date lastPreviewDate) {
+    this.lastPreviewDate = lastPreviewDate == null ? null : new Date(lastPreviewDate.getTime());
+  }
+
+  public int getLastPreviewRecords() {
+    return lastPreviewRecords;
+  }
+
+  public void setLastPreviewRecords(int lastPreviewRecords) {
+    this.lastPreviewRecords = lastPreviewRecords;
+  }
+
+  public boolean isLastPreviewRecordsReadyForViewing() {
+    return lastPreviewRecordsReadyForViewing;
+  }
+
+  public void setLastPreviewRecordsReadyForViewing(boolean lastPreviewRecordsReadyForViewing) {
+    this.lastPreviewRecordsReadyForViewing = lastPreviewRecordsReadyForViewing;
+  }
+
   public Date getFirstPublishedDate() {
-    return firstPublishedDate == null?null:new Date(firstPublishedDate.getTime());
+    return firstPublishedDate == null ? null : new Date(firstPublishedDate.getTime());
   }
 
   public void setFirstPublishedDate(Date firstPublishedDate) {
-    this.firstPublishedDate = firstPublishedDate == null?null:new Date(firstPublishedDate.getTime());
+    this.firstPublishedDate =
+        firstPublishedDate == null ? null : new Date(firstPublishedDate.getTime());
   }
 
   public Date getLastPublishedDate() {
-    return lastPublishedDate == null?null:new Date(lastPublishedDate.getTime());
+    return lastPublishedDate == null ? null : new Date(lastPublishedDate.getTime());
   }
 
   public void setLastPublishedDate(Date lastPublishedDate) {
-    this.lastPublishedDate = lastPublishedDate == null?null:new Date(lastPublishedDate.getTime());
+    this.lastPublishedDate =
+        lastPublishedDate == null ? null : new Date(lastPublishedDate.getTime());
   }
 
   public int getLastPublishedRecords() {
@@ -45,12 +77,21 @@ public class DatasetExecutionInformation {
     this.lastPublishedRecords = lastPublishedRecords;
   }
 
+  public boolean isLastPublishedRecordsReadyForViewing() {
+    return lastPublishedRecordsReadyForViewing;
+  }
+
+  public void setLastPublishedRecordsReadyForViewing(boolean lastPublishedRecordsReadyForViewing) {
+    this.lastPublishedRecordsReadyForViewing = lastPublishedRecordsReadyForViewing;
+  }
+
   public Date getLastHarvestedDate() {
-    return lastHarvestedDate == null?null:new Date(lastHarvestedDate.getTime());
+    return lastHarvestedDate == null ? null : new Date(lastHarvestedDate.getTime());
   }
 
   public void setLastHarvestedDate(Date lastHarvestedDate) {
-    this.lastHarvestedDate = lastHarvestedDate == null?null:new Date(lastHarvestedDate.getTime());
+    this.lastHarvestedDate =
+        lastHarvestedDate == null ? null : new Date(lastHarvestedDate.getTime());
   }
 
   public int getLastHarvestedRecords() {

--- a/metis-core/metis-core-rest/src/main/java/eu/europeana/metis/core/rest/config/ConfigurationPropertiesHolder.java
+++ b/metis-core/metis-core-rest/src/main/java/eu/europeana/metis/core/rest/config/ConfigurationPropertiesHolder.java
@@ -60,6 +60,9 @@ public class ConfigurationPropertiesHolder {
   @Value("${metis.core.baseUrl}")
   private String metisCoreBaseUrl;
 
+  @Value("${solr.commit.period.in.mins}")
+  private int solrCommitPeriodInMins;
+
   @Value("${socks.proxy.enabled}")
   private boolean socksProxyEnabled;
   @Value("${socks.proxy.host}")
@@ -203,6 +206,10 @@ public class ConfigurationPropertiesHolder {
 
   public String getMetisCoreBaseUrl() {
     return metisCoreBaseUrl;
+  }
+
+  public int getSolrCommitPeriodInMins() {
+    return solrCommitPeriodInMins;
   }
 
   public boolean isSocksProxyEnabled() {

--- a/metis-core/metis-core-rest/src/main/java/eu/europeana/metis/core/rest/config/OrchestratorConfig.java
+++ b/metis-core/metis-core-rest/src/main/java/eu/europeana/metis/core/rest/config/OrchestratorConfig.java
@@ -135,11 +135,12 @@ public class OrchestratorConfig extends WebMvcConfigurerAdapter {
     OrchestratorService orchestratorService =
         new OrchestratorService(workflowDao, workflowExecutionDao, datasetDao, datasetXsltDao,
             workflowExecutorManager, redissonClient, authorizer);
-    orchestratorService.setMetisCoreUrl(propertiesHolder.getMetisCoreBaseUrl());
     orchestratorService
         .setValidationExternalProperties(propertiesHolder.getValidationExternalProperties());
     orchestratorService
         .setValidationInternalProperties(propertiesHolder.getValidationInternalProperties());
+    orchestratorService.setMetisCoreUrl(propertiesHolder.getMetisCoreBaseUrl());
+    orchestratorService.setSolrCommitPeriodInMins(propertiesHolder.getSolrCommitPeriodInMins());
     return orchestratorService;
   }
 

--- a/metis-core/metis-core-rest/src/main/resources/metis.properties.example
+++ b/metis-core/metis-core-rest/src/main/resources/metis.properties.example
@@ -44,7 +44,7 @@ redis.enableSSL=
 #True if a custom certificate is used in the truststore defined above
 redis.enable.custom.truststore=
 
-solr.url=
+solr.commit.period.in.mins=
 
 #ECloud
 ecloud.baseUrl=

--- a/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/service/TestOrchestratorService.java
+++ b/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/service/TestOrchestratorService.java
@@ -758,22 +758,22 @@ public class TestOrchestratorService {
     AbstractMetisPlugin oaipmhHarvestPlugin =
         PluginType.OAIPMH_HARVEST.getNewPlugin(new OaipmhHarvestPluginMetadata());
     oaipmhHarvestPlugin.setFinishedDate(
-        DateUtils.modifyDateByTimeUnitAmount(new Date(), SOLR_COMMIT_PERIOD_IN_MINS + 3, TimeUnit.MINUTES));
+        DateUtils.modifyDateByTimeUnitAmount(new Date(), -(SOLR_COMMIT_PERIOD_IN_MINS + 3), TimeUnit.MINUTES));
     oaipmhHarvestPlugin.setExecutionProgress(executionProgress);
     AbstractMetisPlugin firstPublishPlugin =
         PluginType.PUBLISH.getNewPlugin(new IndexToPublishPluginMetadata());
     firstPublishPlugin.setFinishedDate(
-        DateUtils.modifyDateByTimeUnitAmount(new Date(), SOLR_COMMIT_PERIOD_IN_MINS + 2, TimeUnit.MINUTES));
+        DateUtils.modifyDateByTimeUnitAmount(new Date(), -(SOLR_COMMIT_PERIOD_IN_MINS + 2), TimeUnit.MINUTES));
     firstPublishPlugin.setExecutionProgress(executionProgress);
     AbstractMetisPlugin lastPreviewPlugin =
         PluginType.PREVIEW.getNewPlugin(new IndexToPreviewPluginMetadata());
     lastPreviewPlugin.setFinishedDate(
-        DateUtils.modifyDateByTimeUnitAmount(new Date(),SOLR_COMMIT_PERIOD_IN_MINS + 1, TimeUnit.MINUTES));
+        DateUtils.modifyDateByTimeUnitAmount(new Date(),-(SOLR_COMMIT_PERIOD_IN_MINS + 1), TimeUnit.MINUTES));
     lastPreviewPlugin.setExecutionProgress(executionProgress);
     AbstractMetisPlugin lastPublishPlugin =
         PluginType.PUBLISH.getNewPlugin(new IndexToPublishPluginMetadata());
     lastPublishPlugin
-        .setFinishedDate(DateUtils.modifyDateByTimeUnitAmount(new Date(), SOLR_COMMIT_PERIOD_IN_MINS, TimeUnit.MINUTES));
+        .setFinishedDate(DateUtils.modifyDateByTimeUnitAmount(new Date(), -SOLR_COMMIT_PERIOD_IN_MINS, TimeUnit.MINUTES));
     lastPublishPlugin.setExecutionProgress(executionProgress);
 
     final MetisUser metisUser = TestObjectFactory.createMetisUser(TestObjectFactory.EMAIL);

--- a/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/service/TestOrchestratorService.java
+++ b/metis-core/metis-core-service/src/test/java/eu/europeana/metis/core/service/TestOrchestratorService.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.bson.types.ObjectId;
 import org.junit.After;
@@ -757,22 +758,22 @@ public class TestOrchestratorService {
     AbstractMetisPlugin oaipmhHarvestPlugin =
         PluginType.OAIPMH_HARVEST.getNewPlugin(new OaipmhHarvestPluginMetadata());
     oaipmhHarvestPlugin.setFinishedDate(
-        DateUtils.subtractMinutesToDate(SOLR_COMMIT_PERIOD_IN_MINS + 3, new Date()));
+        DateUtils.modifyDateByTimeUnitAmount(new Date(), SOLR_COMMIT_PERIOD_IN_MINS + 3, TimeUnit.MINUTES));
     oaipmhHarvestPlugin.setExecutionProgress(executionProgress);
     AbstractMetisPlugin firstPublishPlugin =
         PluginType.PUBLISH.getNewPlugin(new IndexToPublishPluginMetadata());
     firstPublishPlugin.setFinishedDate(
-        DateUtils.subtractMinutesToDate(SOLR_COMMIT_PERIOD_IN_MINS + 2, new Date()));
+        DateUtils.modifyDateByTimeUnitAmount(new Date(), SOLR_COMMIT_PERIOD_IN_MINS + 2, TimeUnit.MINUTES));
     firstPublishPlugin.setExecutionProgress(executionProgress);
     AbstractMetisPlugin lastPreviewPlugin =
         PluginType.PREVIEW.getNewPlugin(new IndexToPreviewPluginMetadata());
     lastPreviewPlugin.setFinishedDate(
-        DateUtils.subtractMinutesToDate(SOLR_COMMIT_PERIOD_IN_MINS + 1, new Date()));
+        DateUtils.modifyDateByTimeUnitAmount(new Date(),SOLR_COMMIT_PERIOD_IN_MINS + 1, TimeUnit.MINUTES));
     lastPreviewPlugin.setExecutionProgress(executionProgress);
     AbstractMetisPlugin lastPublishPlugin =
         PluginType.PUBLISH.getNewPlugin(new IndexToPublishPluginMetadata());
     lastPublishPlugin
-        .setFinishedDate(DateUtils.subtractMinutesToDate(SOLR_COMMIT_PERIOD_IN_MINS, new Date()));
+        .setFinishedDate(DateUtils.modifyDateByTimeUnitAmount(new Date(), SOLR_COMMIT_PERIOD_IN_MINS, TimeUnit.MINUTES));
     lastPublishPlugin.setExecutionProgress(executionProgress);
 
     final MetisUser metisUser = TestObjectFactory.createMetisUser(TestObjectFactory.EMAIL);


### PR DESCRIPTION
…st index.

On DatasetExecutionInformation there are two new boolean fields that indicate if an index, preview or publish, is "committed" in solr and therefore ready to be searched through the portal.