### PR TITLE
feat/MET-2973_avoid_retrying_dereference_result_if_cache_has_null_or_emtpy_value

### DIFF
--- a/metis-dereference/metis-dereference-service/src/main/java/eu/europeana/metis/dereference/service/utils/VocabularyCandidates.java
+++ b/metis-dereference/metis-dereference-service/src/main/java/eu/europeana/metis/dereference/service/utils/VocabularyCandidates.java
@@ -27,15 +27,15 @@ public final class VocabularyCandidates {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VocabularyCandidates.class);
 
-  private final List<Vocabulary> candidates;
+  private final List<Vocabulary> vocabularies;
 
   /**
    * Constructor.
-   * 
-   * @param candidates The candidates to be in this list.
+   *
+   * @param vocabularies The candidates to be in this list.
    */
-  VocabularyCandidates(List<Vocabulary> candidates) {
-    this.candidates = new ArrayList<>(candidates);
+  VocabularyCandidates(List<Vocabulary> vocabularies) {
+    this.vocabularies = new ArrayList<>(vocabularies);
   }
 
   /**
@@ -84,15 +84,16 @@ public final class VocabularyCandidates {
   }
 
   /**
-   * Collects the suffixes of all the candidates. This method is useful for resolving the resource.
+   * Collects the suffixes of all the vocabulary candidates. This method is useful for resolving
+   * the resource.
    * Note that all the vocabulary candidates must at this point represent the same vocabulary, so
    * the number of suffixes should be very limited (1, if all vocabularies are configured the same
    * way).
-   * 
+   *
    * @return The collection of suffixes. Is not null.
    */
-  public Set<String> getCandidateSuffixes() {
-    return candidates.stream()
+  public Set<String> getVocabulariesSuffixes() {
+    return vocabularies.stream()
         .map(vocabulary -> vocabulary.getSuffix() == null ? "" : vocabulary.getSuffix())
         .collect(Collectors.toSet());
   }
@@ -103,15 +104,15 @@ public final class VocabularyCandidates {
    * @return Whether there are any candidates.
    */
   public boolean isEmpty() {
-    return candidates.isEmpty();
+    return vocabularies.isEmpty();
   }
 
   /**
    * Provides an immutable (read-only) view of the vocabularies in this collection.
-   * 
+   *
    * @return The candidates.
    */
-  public List<Vocabulary> getCandidates() {
-    return Collections.unmodifiableList(candidates);
+  public List<Vocabulary> getVocabularies() {
+    return Collections.unmodifiableList(vocabularies);
   }
 }

--- a/metis-dereference/metis-dereference-service/src/test/java/eu/europeana/metis/dereference/service/MongoDereferenceServiceTest.java
+++ b/metis-dereference/metis-dereference-service/src/test/java/eu/europeana/metis/dereference/service/MongoDereferenceServiceTest.java
@@ -79,7 +79,8 @@ class MongoDereferenceServiceTest {
     place.setAbout(entityId);
 
     // Mock the service
-    doReturn(new ImmutablePair<>(place, geonames)).when(service).retrieveCachedEntity(entityId);
+    doReturn(new ImmutablePair<>(place, geonames)).when(service)
+        .computeEnrichmentBaseVocabularyPair(entityId);
 
     // Test the method
     final EnrichmentResultList result = service.dereference(entityId);
@@ -94,7 +95,7 @@ class MongoDereferenceServiceTest {
     assertThrows(IllegalArgumentException.class, ()->service.dereference(null));
 
     // Test absent object
-    doReturn(null).when(service).retrieveCachedEntity(entityId);
+    doReturn(null).when(service).computeEnrichmentBaseVocabularyPair(entityId);
     final EnrichmentResultList emptyResult = service.dereference(entityId);
     assertNotNull(emptyResult);
     assertNotNull(emptyResult.getEnrichmentBaseWrapperList());

--- a/metis-dereference/metis-dereference-service/src/test/java/eu/europeana/metis/dereference/service/utils/VocabularyCandidatesTest.java
+++ b/metis-dereference/metis-dereference-service/src/test/java/eu/europeana/metis/dereference/service/utils/VocabularyCandidatesTest.java
@@ -51,7 +51,7 @@ class VocabularyCandidatesTest {
     // Match and obtain list of matching vocabularies
     final String resourceId = correctUri + "/123456";
     final List<Vocabulary> result = VocabularyCandidates
-        .findVocabulariesForUrl(resourceId, vocabularyProviderMock).getCandidates();
+        .findVocabulariesForUrl(resourceId, vocabularyProviderMock).getVocabularies();
 
     // Verify that the provider was called exactly once with the right value.
     Mockito.verify(vocabularyProviderMock).apply(Mockito.anyString());
@@ -108,20 +108,20 @@ class VocabularyCandidatesTest {
 
     // Try with all vocabularies
     final Set<String> suffixes1 = new VocabularyCandidates(
-            Arrays.asList(vocabulary1, vocabulary2, vocabulary3)).getCandidateSuffixes();
+        Arrays.asList(vocabulary1, vocabulary2, vocabulary3)).getVocabulariesSuffixes();
     assertEquals(2, suffixes1.size());
     assertTrue(suffixes1.contains(suffixA));
     assertTrue(suffixes1.contains(suffixB));
 
     // Try with one vocabulary
-    final Set<String> suffixes2 =
-        new VocabularyCandidates(Collections.singletonList(vocabulary1)).getCandidateSuffixes();
+    final Set<String> suffixes2 = new VocabularyCandidates(Collections.singletonList(vocabulary1))
+        .getVocabulariesSuffixes();
     assertEquals(1, suffixes2.size());
     assertTrue(suffixes2.contains(suffixA));
 
     // Try with no vocabularies
-    final Set<String> suffixes3 =
-        new VocabularyCandidates(Collections.emptyList()).getCandidateSuffixes();
+    final Set<String> suffixes3 = new VocabularyCandidates(Collections.emptyList())
+        .getVocabulariesSuffixes();
     assertTrue(suffixes3.isEmpty());
   }
 


### PR DESCRIPTION
Storing both null for a transformed entity and a vocabulary is not possible anymore.
Storing of null of the transformed entity and a non null vocabulary is possible, and indicates that for a given resource a transformed result was null