### PR TITLE
Feat/met 3477 update mongo morphia

### DIFF
--- a/metis-common/metis-common-mongo/pom.xml
+++ b/metis-common/metis-common-mongo/pom.xml
@@ -25,11 +25,6 @@
       <artifactId>corelib-storage</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-    </dependency>
-    <dependency>
       <groupId>dev.morphia.morphia</groupId>
       <artifactId>morphia-core</artifactId>
       <version>${version.morphia.core}</version>

--- a/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
+++ b/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
@@ -3,11 +3,11 @@ package eu.europeana.metis.mongo.embedded;
 import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.config.RuntimeConfigBuilder;
 import de.flapdoodle.embed.mongo.distribution.Version;
-import de.flapdoodle.embed.process.config.IRuntimeConfig;
+import de.flapdoodle.embed.process.config.RuntimeConfig;
 import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.runtime.Network;
 import eu.europeana.metis.network.NetworkUtil;
@@ -39,14 +39,17 @@ public class EmbeddedLocalhostMongo {
     if (mongodExecutable == null) {
       try {
         mongoPort = NetworkUtil.getAvailableLocalPort();
-        IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder()
-            .defaultsWithLogger(Command.MongoD, LOGGER)
+        RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(Command.MongoD, LOGGER)
             .processOutput(ProcessOutput.getDefaultInstanceSilent())
             .build();
 
+        MongodConfig mongodConfig = MongodConfig.builder()
+            .version(Version.V4_0_12)
+            .net(new Net(DEFAULT_MONGO_HOST, mongoPort, Network.localhostIsIPv6()))
+            .build();
+
         MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-        mongodExecutable = runtime.prepare(new MongodConfigBuilder().version(Version.V3_6_5)
-            .net(new Net(DEFAULT_MONGO_HOST, mongoPort, Network.localhostIsIPv6())).build());
+        mongodExecutable = runtime.prepare(mongodConfig);
         mongodExecutable.start();
       } catch (IOException e) {
         LOGGER.error("Exception when starting embedded mongo", e);

--- a/metis-core/metis-core-common/pom.xml
+++ b/metis-core/metis-core-common/pom.xml
@@ -67,11 +67,6 @@
       <version>${version.spring}</version>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/metis-core/metis-core-service/pom.xml
+++ b/metis-core/metis-core-service/pom.xml
@@ -41,11 +41,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/metis-data-checker/metis-data-checker-service/pom.xml
+++ b/metis-data-checker/metis-data-checker-service/pom.xml
@@ -26,12 +26,6 @@
       <groupId>eu.europeana.metis</groupId>
       <artifactId>metis-data-checker-common</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.mongodb</groupId>
-          <artifactId>mongodb-driver-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>eu.europeana.metis</groupId>

--- a/metis-dereference/metis-dereference-service/pom.xml
+++ b/metis-dereference/metis-dereference-service/pom.xml
@@ -38,11 +38,6 @@
       <version>${version.jackson}</version>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
       <version>${version.spring}</version>

--- a/metis-enrichment/metis-enrichment-common/pom.xml
+++ b/metis-enrichment/metis-enrichment-common/pom.xml
@@ -38,12 +38,6 @@
       <artifactId>jaxb-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
       <version>${version.jackson}</version>

--- a/metis-enrichment/metis-enrichment-rest/pom.xml
+++ b/metis-enrichment/metis-enrichment-rest/pom.xml
@@ -43,11 +43,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-    </dependency>
-    <dependency>
       <groupId>eu.europeana.corelib</groupId>
       <artifactId>corelib-web</artifactId>
     </dependency>

--- a/metis-enrichment/metis-enrichment-service/pom.xml
+++ b/metis-enrichment/metis-enrichment-service/pom.xml
@@ -79,11 +79,6 @@
       <artifactId>xercesImpl</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-    </dependency>
-    <dependency>
       <groupId>eu.europeana.corelib</groupId>
       <artifactId>corelib-storage</artifactId>
     </dependency>

--- a/metis-indexing/pom.xml
+++ b/metis-indexing/pom.xml
@@ -49,11 +49,6 @@
       <version>${version.log4j}</version>
     </dependency>
     <dependency>
-      <groupId>org.mongodb</groupId>
-      <artifactId>mongodb-driver-core</artifactId>
-      <version>${version.mongodb.driver.core}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <version.junit>5.7.1</version.junit>
     <version.junit5.vintage.version>5.1.0</version.junit5.vintage.version>
     <version.awaitability>1.7.0</version.awaitability>
-    <version.embedded.mongo>2.2.0</version.embedded.mongo>
+    <version.embedded.mongo>3.0.0</version.embedded.mongo>
     <version.mongodb.driver.core>4.0.2</version.mongodb.driver.core>
     <version.javax.persistence>1.0.2</version.javax.persistence>
     <version.commons.io>2.8.0</version.commons.io>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,6 @@
     <version.junit5.vintage.version>5.1.0</version.junit5.vintage.version>
     <version.awaitability>1.7.0</version.awaitability>
     <version.embedded.mongo>3.0.0</version.embedded.mongo>
-    <version.mongodb.driver.core>4.0.2</version.mongodb.driver.core>
     <version.javax.persistence>1.0.2</version.javax.persistence>
     <version.commons.io>2.8.0</version.commons.io>
     <version.commons.lang3>3.12.0</version.commons.lang3>
@@ -92,7 +91,7 @@
     <version.corelib>2.12.2-SNAPSHOT</version.corelib>
     <version.servlet.api>4.0.1</version.servlet.api>
     <version.commons-fileupload>1.4</version.commons-fileupload>
-    <version.morphia.core>2.0.0</version.morphia.core>
+    <version.morphia.core>2.1.4</version.morphia.core>
     <version.xsom>20140925</version.xsom>
     <version.commonscompress>1.11</version.commonscompress>
     <version.spring.security>5.3.2.RELEASE</version.spring.security>
@@ -166,7 +165,7 @@
           </exclusion>
           <exclusion>
             <groupId>dev.morphia.morphia</groupId>
-            <artifactId>core</artifactId>
+            <artifactId>morphia-core</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.solr</groupId>


### PR DESCRIPTION
mongodb-driver-core was removed since it's not required to be explicitly declared.
We are dependent on morphia which should come with it's own required mongo libraries.