### PR TITLE
Fix xml:lang in rdf:resource refs

### DIFF
--- a/metis-core/metis-core-rest/src/main/resources/default_transformation.xslt
+++ b/metis-core/metis-core-rest/src/main/resources/default_transformation.xslt
@@ -421,11 +421,11 @@
           <xsl:copy-of select="@rdf:resource"/>
         </xsl:when>
         <xsl:otherwise>
-		      <xsl:copy-of select="@xml:lang"/>
-		      <xsl:copy-of select="@rdf:datatype"/>
+          <xsl:copy-of select="@xml:lang"/>
+          <xsl:copy-of select="@rdf:datatype"/>
+          <xsl:apply-templates select="node()"/>
         </xsl:otherwise>
       </xsl:choose>
-      <xsl:apply-templates select="node()"/>
     </xsl:element>
   </xsl:template>
   <!-- ************************************************ -->

--- a/metis-core/metis-core-rest/src/main/resources/default_transformation.xslt
+++ b/metis-core/metis-core-rest/src/main/resources/default_transformation.xslt
@@ -416,9 +416,15 @@
   </xsl:template>
   <xsl:template match="*">
     <xsl:element name="{name()}">
-      <xsl:copy-of select="@rdf:resource"/>
-      <xsl:copy-of select="@xml:lang"/>
-      <xsl:copy-of select="@rdf:datatype"/>
+      <xsl:choose>
+        <xsl:when test="@rdf:resource">
+          <xsl:copy-of select="@rdf:resource"/>
+        </xsl:when>
+        <xsl:otherwise>
+		      <xsl:copy-of select="@xml:lang"/>
+		      <xsl:copy-of select="@rdf:datatype"/>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:apply-templates select="node()"/>
     </xsl:element>
   </xsl:template>


### PR DESCRIPTION
This is a fix to make the XSLT more resilient to cases when both the xml:lang and rdf:resource are present. This issue happens on the JHN dataset. 