### PR TITLE
Feat/met 4106 check on dependencies update log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   <properties>
     <version.jena.iri>4.1.0</version.jena.iri>
     <version.ecloud>6-SNAPSHOT</version.ecloud>
-    <version.corelib>2.14.1-SNAPSHOT</version.corelib>
+    <version.corelib>2.15.3</version.corelib>
     <version.redisson>3.15.5</version.redisson>
     <version.maven.compiler.plugin>3.8.1</version.maven.compiler.plugin>
     <version.maven.release>2.5.3</version.maven.release>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <!-- These two versions are interdependent. -->
     <version.slf4j>1.7.30</version.slf4j>
     <version.jul.to.slf4j>1.7.30</version.jul.to.slf4j>
-    <version.log4j>2.17.0</version.log4j>
+    <version.log4j>2.17.1</version.log4j>
 
     <version.surefire.plugin>2.22.1</version.surefire.plugin>
     <version.junit>5.7.2</version.junit>


### PR DESCRIPTION
Update log4j version from 2.17.0 to 2.17.1 to fix CVE-2021-44832