### PR TITLE
feat/MET-4720_MET-4761 add skos notation date normalization data to mongo

### DIFF
--- a/metis-indexing/src/main/java/eu/europeana/indexing/fullbean/TimespanFieldInput.java
+++ b/metis-indexing/src/main/java/eu/europeana/indexing/fullbean/TimespanFieldInput.java
@@ -32,6 +32,7 @@ final class TimespanFieldInput implements Function<TimeSpanType, TimespanImpl> {
     mongoTimespan.setIsNextInSequence(
         Optional.ofNullable(timeSpan.getIsNextInSequence()).map(IsNextInSequence::getResource)
             .orElse(null));
+    mongoTimespan.setSkosNotation(FieldInputUtils.createLiteralMapFromString(timeSpan.getNotation()));
     return mongoTimespan;
   }
 }

--- a/metis-indexing/src/main/java/eu/europeana/indexing/mongo/TimespanUpdater.java
+++ b/metis-indexing/src/main/java/eu/europeana/indexing/mongo/TimespanUpdater.java
@@ -23,5 +23,6 @@ public class TimespanUpdater extends AbstractIsolatedEdmEntityUpdater<TimespanIm
     propertyUpdater.updateMap("isPartOf", TimespanImpl::getIsPartOf);
     propertyUpdater.updateMap("dctermsHasPart", TimespanImpl::getDctermsHasPart);
     propertyUpdater.updateArray("owlSameAs", TimespanImpl::getOwlSameAs);
+    propertyUpdater.updateMap("notation", TimespanImpl::getSkosNotation);
   }
 }

--- a/metis-indexing/src/test/java/eu/europeana/indexing/mongo/TimespanUpdaterTest.java
+++ b/metis-indexing/src/test/java/eu/europeana/indexing/mongo/TimespanUpdaterTest.java
@@ -40,7 +40,7 @@ class TimespanUpdaterTest extends MongoEntityUpdaterTest<TimespanImpl> {
     testMapPropertyUpdate(propertyUpdater, "isPartOf", TimespanImpl::setIsPartOf);
     testMapPropertyUpdate(propertyUpdater, "dctermsHasPart", TimespanImpl::setDctermsHasPart);
     testArrayPropertyUpdate(propertyUpdater, "owlSameAs", TimespanImpl::setOwlSameAs);
-
+    testMapPropertyUpdate(propertyUpdater, "notation", TimespanImpl::setSkosNotation);
     // And that should be it.
     verifyNoMoreInteractions(propertyUpdater);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <version.com.zoho.crm.java-sdk>3.0.1</version.com.zoho.crm.java-sdk>
     <version.apache.commons.text>1.9</version.apache.commons.text>
     <version.commonscompress>1.21</version.commonscompress>
-    <version.corelib>2.15.3</version.corelib>
+    <version.corelib>2.15.8</version.corelib>
 
     <!-- These two versions are interdependent. -->
     <version.directory.maven.plugin>1.0</version.directory.maven.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <version.com.zoho.crm.java-sdk>3.0.1</version.com.zoho.crm.java-sdk>
     <version.apache.commons.text>1.9</version.apache.commons.text>
     <version.commonscompress>1.21</version.commonscompress>
-    <version.corelib>2.15.8</version.corelib>
+    <version.corelib>2.15.8-SNAPSHOT</version.corelib>
 
     <!-- These two versions are interdependent. -->
     <version.directory.maven.plugin>1.0</version.directory.maven.plugin>


### PR DESCRIPTION
**remark**: we will need to wait until corelib makes their official release. The pom needs to run with 2.15.8. At the moment  works with 2.15.8-SNAPSHOT version of corelib.