### PR TITLE
Update flapdoodle version and in memory mongo version

### DIFF
--- a/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
+++ b/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
@@ -4,7 +4,7 @@ package eu.europeana.metis.mongo.embedded;
 import de.flapdoodle.embed.mongo.commands.ImmutableMongodArguments;
 import de.flapdoodle.embed.mongo.commands.MongodArguments;
 import de.flapdoodle.embed.mongo.config.Net;
-import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.distribution.Version.Main;
 import de.flapdoodle.embed.mongo.transitions.ImmutableMongod;
 import de.flapdoodle.embed.mongo.transitions.Mongod;
 import de.flapdoodle.embed.mongo.transitions.RunningMongodProcess;
@@ -61,7 +61,7 @@ public class EmbeddedLocalhostMongo {
                                        .withProcessOutput(Start.to(ProcessOutput.class).initializedWith(processOutput))
                                        .withMongodArguments(Start.to(MongodArguments.class).initializedWith(mongodArguments));
 
-        runningMongodProcessReachedState = mongod.start(Version.Main.V4_4);
+        runningMongodProcessReachedState = mongod.start(Main.V5_0);
 
       } catch (IOException e) {
         LOGGER.error("Exception when starting embedded mongo", e);

--- a/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
+++ b/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
@@ -15,10 +15,9 @@ import de.flapdoodle.embed.process.io.Slf4jLevel;
 import de.flapdoodle.reverse.TransitionWalker;
 import de.flapdoodle.reverse.transitions.Start;
 import eu.europeana.metis.network.NetworkUtil;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
  * Starts an in memory Mongo database. This class is to be used for unit testing on localhost.
@@ -29,15 +28,15 @@ public class EmbeddedLocalhostMongo {
 
   private static final String DEFAULT_MONGO_HOST = "127.0.0.1";
   private static final ImmutableProcessOutput processOutput = ProcessOutput.builder()
-          .commands(Processors.logTo(LOGGER, Slf4jLevel.DEBUG))
-          .output(Processors.logTo(LOGGER, Slf4jLevel.INFO))
-          .error(Processors.logTo(LOGGER, Slf4jLevel.ERROR))
-          .build();
+                                                                           .commands(Processors.logTo(LOGGER, Slf4jLevel.DEBUG))
+                                                                           .output(Processors.logTo(LOGGER, Slf4jLevel.INFO))
+                                                                           .error(Processors.logTo(LOGGER, Slf4jLevel.ERROR))
+                                                                           .build();
 
   private static final ImmutableMongodArguments mongodArguments = MongodArguments.defaults()
-          .withSyncDelay(0)
-          .withStorageEngine("ephemeralForTest")
-          .withUseNoJournal(true);
+                                                                                 .withSyncDelay(0)
+                                                                                 .withStorageEngine("ephemeralForTest")
+                                                                                 .withUseNoJournal(true);
 
   private TransitionWalker.ReachedState<RunningMongodProcess> runningMongodProcessReachedState;
   private int mongoPort;
@@ -57,9 +56,10 @@ public class EmbeddedLocalhostMongo {
       try {
         mongoPort = new NetworkUtil().getAvailableLocalPort();
         ImmutableMongod mongod = Mongod.instance()
-                .withNet(Start.to(Net.class).initializedWith(Net.builder().bindIp(DEFAULT_MONGO_HOST).port(mongoPort).isIpv6(true).build()))
-                .withProcessOutput(Start.to(ProcessOutput.class).initializedWith(processOutput))
-                .withMongodArguments(Start.to(MongodArguments.class).initializedWith(mongodArguments));
+                                       .withNet(Start.to(Net.class).initializedWith(
+                                           Net.builder().bindIp(DEFAULT_MONGO_HOST).port(mongoPort).isIpv6(true).build()))
+                                       .withProcessOutput(Start.to(ProcessOutput.class).initializedWith(processOutput))
+                                       .withMongodArguments(Start.to(MongodArguments.class).initializedWith(mongodArguments));
 
         runningMongodProcessReachedState = mongod.start(Version.Main.V4_4);
 

--- a/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
+++ b/metis-common/metis-common-mongo/src/main/java/eu/europeana/metis/mongo/embedded/EmbeddedLocalhostMongo.java
@@ -61,7 +61,7 @@ public class EmbeddedLocalhostMongo {
                                        .withProcessOutput(Start.to(ProcessOutput.class).initializedWith(processOutput))
                                        .withMongodArguments(Start.to(MongodArguments.class).initializedWith(mongodArguments));
 
-        runningMongodProcessReachedState = mongod.start(Main.V5_0);
+        runningMongodProcessReachedState = mongod.start(Main.V6_0);
 
       } catch (IOException e) {
         LOGGER.error("Exception when starting embedded mongo", e);

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <version.commons-compress>1.26.0</version.commons-compress>
     <version.corelib>2.16.10-SNAPSHOT</version.corelib>
     <version.gdcc.xoai>5.2.0</version.gdcc.xoai>
-    <version.embedded.mongo>4.17.0</version.embedded.mongo>
+    <version.embedded.mongo>4.18.1</version.embedded.mongo>
     <version.hamcrest>1.3</version.hamcrest>
     <version.hibernate.core>6.4.4.Final</version.hibernate.core>
     <version.postgresql>42.7.2</version.postgresql>


### PR DESCRIPTION
This change is due to the fact that GitHub now uses automatically ubuntu 24.x which started to make flapdoodle tests fail.