### PR TITLE
MET-6143 Fix runtime exception being caught and not propagated

### DIFF
--- a/metis-enrichment/metis-enrichment-client/src/main/java/eu/europeana/enrichment/rest/client/dereference/DereferencerImpl.java
+++ b/metis-enrichment/metis-enrichment-client/src/main/java/eu/europeana/enrichment/rest/client/dereference/DereferencerImpl.java
@@ -47,7 +47,7 @@ import org.springframework.web.client.HttpClientErrorException.BadRequest;
 public class DereferencerImpl implements Dereferencer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DereferencerImpl.class);
-  public static final String CANCELLATION_EXCEPTION_WARN_MESSAGE = "Cancellation exception occurred while trying to perform dereferencing, rethrowing.";
+  private static final String CANCELLATION_EXCEPTION_WARN_MESSAGE = "Cancellation exception occurred while trying to perform dereferencing, rethrowing.";
 
   private final EntityMergeEngine entityMergeEngine;
   private final EntityResolver entityResolver;

--- a/metis-enrichment/metis-enrichment-client/src/main/java/eu/europeana/enrichment/rest/client/dereference/DereferencerImpl.java
+++ b/metis-enrichment/metis-enrichment-client/src/main/java/eu/europeana/enrichment/rest/client/dereference/DereferencerImpl.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CancellationException;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
@@ -249,6 +250,8 @@ public class DereferencerImpl implements Dereferencer {
                    result.putIfAbsent(notFoundOwnId, Collections.emptyList());
                  });
       return new DereferencedEntities(result, reports, classType);
+    } catch (CancellationException e){
+      throw e;
     } catch (Exception e) {
       return handleDereferencingException(resourceIds, reports, e, classType);
     }
@@ -262,6 +265,8 @@ public class DereferencerImpl implements Dereferencer {
     }
     try {
       return new DereferencedEntities(new HashMap<>(entityResolver.resolveByUri(resourceIds)), reports, classType);
+    } catch (CancellationException e){
+      throw e;
     } catch (Exception e) {
       return handleDereferencingException(resourceIds, reports, e, classType);
     }
@@ -302,6 +307,8 @@ public class DereferencerImpl implements Dereferencer {
             .withException(e)
             .build());
         result = null;
+      } catch (CancellationException e){
+        throw e;
       } catch (Exception e) {
         DereferenceException dereferenceException = new DereferenceException(
             "Exception occurred while trying to perform dereferencing.", e);

--- a/metis-enrichment/metis-enrichment-client/src/main/java/eu/europeana/enrichment/rest/client/dereference/DereferencerImpl.java
+++ b/metis-enrichment/metis-enrichment-client/src/main/java/eu/europeana/enrichment/rest/client/dereference/DereferencerImpl.java
@@ -47,6 +47,7 @@ import org.springframework.web.client.HttpClientErrorException.BadRequest;
 public class DereferencerImpl implements Dereferencer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DereferencerImpl.class);
+  public static final String CANCELLATION_EXCEPTION_WARN_MESSAGE = "Cancellation exception occurred while trying to perform dereferencing, rethrowing.";
 
   private final EntityMergeEngine entityMergeEngine;
   private final EntityResolver entityResolver;
@@ -251,6 +252,7 @@ public class DereferencerImpl implements Dereferencer {
                  });
       return new DereferencedEntities(result, reports, classType);
     } catch (CancellationException e){
+      LOGGER.warn(CANCELLATION_EXCEPTION_WARN_MESSAGE);
       throw e;
     } catch (Exception e) {
       return handleDereferencingException(resourceIds, reports, e, classType);
@@ -266,6 +268,7 @@ public class DereferencerImpl implements Dereferencer {
     try {
       return new DereferencedEntities(new HashMap<>(entityResolver.resolveByUri(resourceIds)), reports, classType);
     } catch (CancellationException e){
+      LOGGER.warn(CANCELLATION_EXCEPTION_WARN_MESSAGE);
       throw e;
     } catch (Exception e) {
       return handleDereferencingException(resourceIds, reports, e, classType);
@@ -308,6 +311,7 @@ public class DereferencerImpl implements Dereferencer {
             .build());
         result = null;
       } catch (CancellationException e){
+        LOGGER.warn(CANCELLATION_EXCEPTION_WARN_MESSAGE);
         throw e;
       } catch (Exception e) {
         DereferenceException dereferenceException = new DereferenceException(


### PR DESCRIPTION
Could anyone take a look why this changes could cause those issues in build? 
As far as I see tests are failing when setting up Mongo db for test. I cannot recreate those issues locally but maybe I am not aware of something.

Also could you tell me if that change is appropriate? We need to not catch runtime exceptions like Interruption Exceptions or Cancellation Exceptions for Flink to handle task cancellation properly without any work-arounds.